### PR TITLE
bump-version-bounds

### DIFF
--- a/shh-extras/shh-extras.cabal
+++ b/shh-extras/shh-extras.cabal
@@ -20,7 +20,7 @@ source-repository head
 library
   exposed-modules: Shh.Prompt
   build-depends:
-    base >=4.11 && <4.13,
+    base >=4.11 && <4.15,
     shh  >= 0.2.0.0,
     time,
     hostname

--- a/shh/shh.cabal
+++ b/shh/shh.cabal
@@ -23,7 +23,7 @@ library
   exposed-modules:     Shh
                      , Shh.Internal
   build-depends:
-    base             >= 4.9 && < 4.13,
+    base             >= 4.9 && < 4.15,
     async            >= 2.2.1 && < 2.3,
     bytestring,
     deepseq          >= 1.4.3 && < 1.5,
@@ -33,7 +33,7 @@ library
     process          >= 1.6.3 && < 1.7,
     split            >= 0.2.3 && < 0.3,
     stringsearch     >= 0.3.6.6 && < 0.4,
-    template-haskell >= 2.13.0 && < 2.15,
+    template-haskell >= 2.13.0 && < 2.17,
     containers       >= 0.5.11 && < 0.7,
     unix             >= 2.7.2 && < 2.8,
     utf8-string


### PR DESCRIPTION
`shh` still builds and works with newer base as far as I can tell.

I use `shh` from nixpkgs. If you could make a new release with the pushed bounds I will see to it, that `shh` will be marked unbroken in nixpkgs.