### PR TITLE
Remove accidental strictness in |>

### DIFF
--- a/shh/ChangeLog.md
+++ b/shh/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for shh
 
+## 0.7.1.4 -- 2021-06-30
+
+* Fix a bug where `|>` was too strict, causing SIGPIPE
+  to be triggered (ResourceVanished).
+
 ## 0.7.1.3 -- 2021-06-30
 
 * Expose the ToFilePath class.

--- a/shh/src/Shh/Internal.hs
+++ b/shh/src/Shh/Internal.hs
@@ -140,7 +140,6 @@ pipe (Proc a) (Proc b) = buildProc $ \i o e ->
             b' = b r o e `finally` (hClose r)
         concurrently a' b'
 
-
 -- | Like @`pipe`@, but plumbs stderr. See the warning in @`pipe`@.
 pipeErr :: Shell f => Proc a -> Proc b -> f (a, b)
 pipeErr (Proc a) (Proc b) = buildProc $ \i o e -> do
@@ -169,7 +168,7 @@ pipeErr (Proc a) (Proc b) = buildProc $ \i o e -> do
 (|>) :: Shell f => Proc a -> Proc b -> f b
 a |> b = runProc $ do
     v <- fmap snd (a `pipe` b)
-    pure $! v
+    pure v
 infixl 1 |>
 
 
@@ -188,7 +187,7 @@ infixl 1 |>
 (|!>) :: Shell f => Proc a -> Proc b -> f b
 a |!> b = runProc $ do
     v <- fmap snd (a `pipeErr` b)
-    pure $! v
+    pure v
 infixl 1 |!>
 
 -- | Things that can be converted to a @`FilePath`@.

--- a/shh/test/Test.hs
+++ b/shh/test/Test.hs
@@ -121,6 +121,9 @@ unitTests = testGroup "Unit tests"
     , testCase "Long pipe" $ do
         r <- echo "test" |> tr "-d" "e" |> tr "-d" "s" |> capture
         r @?= "tt\n"
+    , testCase "SIGPIPE nativeProc" $ do
+        r <- pureProc (\_ -> BS.cycle "y\n") |> pureProc (\_ -> BS.cycle "y\n") |> exitCode (exe "true")
+        r @?= 0
     , testCase "Pipe stderr" $ replicateM_ 100 $ do
         r <- echo "test" &> StdErr |!> cat |> capture
         r @?= "test\n"


### PR DESCRIPTION
This allows resource vanished exceptions in long chains to be ignored

